### PR TITLE
[#2] Restore defwalker-handler declare

### DIFF
--- a/src/walk.lisp
+++ b/src/walk.lisp
@@ -972,6 +972,14 @@
                                      :read-only (third form))
     (setf (body load-time-value) (second form))))
 
+;;;; DECLARE
+
+(defclass declare-form (form)
+  ((body :accessor body :initarg :body)))
+
+(defwalker-handler declare (form parent env)
+  (with-form-object
+      (declare declare-form :body form)))
 
 ;;;; ** Implementation specific walkers
 


### PR DESCRIPTION
@bobbysmith007

Hi Russ,

This is the first of a couple of PRs I’m planning to submit for Arnesi.

I’ve identified a critical issue with Arnesi for SBCL >= 2.4.4, which makes UCW unusable. However, this is unrelated to the current PR, and I’ll be opening a separate issue and PR to address it.

In this PR, I’m focusing on restoring the walker handler for `declare` forms. This change allows the test suite to compile and load successfully again.

Here are the results I observed on SBCL 2.4.9 after this fix:

```
Did 330 checks.
   Pass: 317 (96%)
   Skip: 0 ( 0%)
   Fail: 13 ( 3%)
```

Please let me know if any changes are needed.